### PR TITLE
update cache before install

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -28,6 +28,7 @@
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
+    update_cache: true
   become: true
   environment:
     GITLAB_RUNNER_DISABLE_SKEL: "true"
@@ -37,6 +38,7 @@
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
+    update_cache: true
   become: true
   when: ansible_distribution_version != "10"
 


### PR DESCRIPTION
This will ensure that the `apt-get update` is run before the `apt-get install` command. It guarantees that the process gets the latest available versions from the official repository.